### PR TITLE
Display error messages properly

### DIFF
--- a/makefile
+++ b/makefile
@@ -70,5 +70,8 @@ deepclean:
 main:
 	$(compiler) $(cflags) $(target)
 
+debug:
+	$(compiler) $(cflags) --debug $(target)
+
 print-%  : ; @echo $* = $($*)
 

--- a/src/errors.py
+++ b/src/errors.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""
+Helpers for graphical error messages.
+
+Should not require any 3rd-party or unsafe modules.
+
+Py6 compliant.
+"""
+
+try:
+    import tkinter as tk
+    import tkinter.messagebox as messagebox
+except ImportError:
+    import Tkinter as tk
+    import tkMessageBox as messagebox
+
+# py2 proofing
+import sys
+
+def display_error(exception):
+    
+    message = "wut"
+    if sys.version_info[0] == 2:
+        message = exception.message
+    else:
+        # assume python 3, doubt many are running py1...
+        message = exception.args[0]
+    
+    messagebox.showerror('Error', message)
+    
+    raise exception

--- a/src/errors.py
+++ b/src/errors.py
@@ -17,7 +17,7 @@ except ImportError:
 # py2 proofing
 import sys
 
-def display_error(exception):
+def display_error(exception, raise_when_done=True):
     
     message = "wut"
     if sys.version_info[0] == 2:
@@ -28,7 +28,10 @@ def display_error(exception):
     
     messagebox.showerror('Error', message)
     
-    raise exception
+    if raise_when_done:
+        # re-raise the exception when done...
+        # makes it easier to trace errors for console users
+        raise exception
 
 def display_warning(message):
     

--- a/src/errors.py
+++ b/src/errors.py
@@ -18,21 +18,21 @@ except ImportError:
 import sys
 
 def display_error(exception, raise_when_done=True):
-    
+
     message = "wut"
     if sys.version_info[0] == 2:
         message = exception.message
     else:
         # assume python 3, doubt many are running py1...
         message = exception.args[0]
-    
+
     messagebox.showerror('Error', message)
-    
+
     if raise_when_done:
         # re-raise the exception when done...
         # makes it easier to trace errors for console users
         raise exception
 
 def display_warning(message):
-    
+
     messagebox.showwarning('Warning', message)

--- a/src/errors.py
+++ b/src/errors.py
@@ -29,3 +29,7 @@ def display_error(exception):
     messagebox.showerror('Error', message)
     
     raise exception
+
+def display_warning(message):
+    
+    messagebox.showwarning('Warning', message)

--- a/src/gui.py
+++ b/src/gui.py
@@ -527,4 +527,8 @@ class SpeedTesterGUI(object):
         self.resnet_button.grid(row=7, column=1, sticky=tk.W)
 
 if __name__ == '__main__':
-    stg = SpeedTesterGUI()
+    
+    try:
+        stg = SpeedTesterGUI()
+    except Exception as exc:
+        errors.display_error(exc, raise_when_done=False)

--- a/src/gui.py
+++ b/src/gui.py
@@ -35,7 +35,7 @@ download_dependencies()  # pretty please work
 from pyspeedtest import pretty_speed
 
 # showing errors
-import traceback
+import errors
 
 # letters
 import string
@@ -177,10 +177,6 @@ class SpeedTesterGUI(object):
             elif sys.version_info[0] == 3:
                 messagebox.showerror("PySpeedTest Broke",
                                      sys.exc_info()[0])
-            
-    def show_error(self, *args):
-        err = traceback.format_exception(*args)
-        messagebox.showerror('Exception',err)
             
     def update_statistics(self):
         """

--- a/src/gui.py
+++ b/src/gui.py
@@ -261,7 +261,10 @@ class SpeedTesterGUI(object):
         """
         Create the statistical analysis file.
         """
-        run_analytics()
+        try:
+            run_analytics()
+        except Exception as exc:
+            errors.display_error(exc, False)
 
     def upload_data(self):
         """

--- a/src/settings.py
+++ b/src/settings.py
@@ -13,6 +13,8 @@ if sys.version_info[0] == 2:
 elif sys.version_info[0] == 3:
     import configparser
 
+import errors
+
 CONFIG_FILE_NAME = "config.ini"
 
 EMERGENCY_DEFAULT = """
@@ -89,4 +91,4 @@ except (configparser.NoSectionError, configparser.NoOptionError) as exc:
     msg += "you updated the problem recently?  I restored it to the\n"
     msg += "default state, try loading the program again.\n\n"
     
-    raise Exception(msg)
+    errors.display_error(Exception(msg))


### PR DESCRIPTION
Actually display a helpful (if not to user, then to me) error message instead of the rather generic "Failed to execute script gui" from PyInstaller.